### PR TITLE
Fix issue with preRestart missing a method parameter for the message.

### DIFF
--- a/lib/mikka.rb
+++ b/lib/mikka.rb
@@ -64,13 +64,16 @@ module Mikka
     def receive(message); end
     def pre_start; end
     def post_stop; end
-    def pre_restart(reason); end
+    def pre_restart(reason, message); end
     def post_restart(reason); end
 
     def onReceive(message); receive(message); end
     def preStart; super; pre_start; end
     def postStop; super; post_stop; end
-    def preRestart(reason); super; pre_restart(reason); end
+    def preRestart(reason, message_option) 
+      super 
+      pre_restart(reason, message_option.is_defined ? message_option.get : nil)
+    end
     def postRestart(reason); super; post_restart(reason); end
   end
 


### PR DESCRIPTION
In Akka, preRestart method is defined as:

``` java
  public void preRestart(Throwable reason, Option<Object> message)
```

But Mikka is only defining the method as a single parameter:

``` ruby
def pre_restart(reason); end
def preRestart(reason); super; pre_restart(reason); end
```

This is causing an issue with actor restarts on line 91 of mikka.rb, which is throwing this exception:

```
org.jruby.exceptions.RaiseException: (ArgumentError) wrong number of arguments (2 for 1) 
```

This PR fixes this issue by adding the missing message option parameter
- Adds missing method parameter to Java and Ruby methods
- In order to avoid dealing with Option in Ruby, extracts value from option if defined, otherwise pass nil.
