### PR TITLE
Add support for declaring supervision strategy on actors

### DIFF
--- a/lib/akka.rb
+++ b/lib/akka.rb
@@ -11,6 +11,13 @@ module Akka
     java_import 'akka.actor.UntypedActor'
     java_import 'akka.actor.Props'
     java_import 'akka.actor.Terminated'
+    java_import 'akka.actor.AllForOneStrategy'
+    java_import 'akka.actor.OneForOneStrategy'   
+    java_import 'akka.actor.SupervisorStrategy'        
+  end
+
+  module Japi
+    java_import 'akka.japi.Function'
   end
 
   module Dispatch


### PR DESCRIPTION
Hello, I added a patch to support supervision strategy in a ruby-like way, 
so thought it could be useful, feel free to modify/adapt it.

**Description:**
- Add OneForOneStrategy and AllForOneStrategy classes
- Use a block on supervisor strategy construction to create decider function 
  which decides what to do based on error
- Block should return :escalate, :stop, :restart, or :resume based on exception

Example usage: 

```
  # declared in actor
  def supervisor_strategy 
    @strategy ||= Mikka::OneForOneStrategy.new(10, Mikka::Duration["1 minute"]) do |e|      
      :restart
    end
  end
```
